### PR TITLE
Add a helper to fix neutron database after upgrade

### DIFF
--- a/lib/quantum-to-neutron-helper
+++ b/lib/quantum-to-neutron-helper
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+#
+# Copyright 2014, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import ConfigParser
+import os
+import sqlalchemy
+import sys
+
+if len(sys.argv) != 2:
+   print >>sys.stderr, 'Usage: %s DOMAIN' % sys.argv[0]
+   sys.exit(1)
+
+domain = sys.argv[1]
+if not domain:
+   print >>sys.stderr, 'Domain is empty, doing nothing.'
+   sys.exit(0)
+
+if domain[0] != '.':
+   domain = '.%s' % domain
+
+
+def get_db_uri(file, group, option):
+    if not os.path.exists(file):
+        return None
+
+    config = ConfigParser.SafeConfigParser()
+    config.read(file)
+    try:
+        return config.get(group, option)
+    except ConfigParser.Error as e:
+        print >>sys.stderr, 'Cannot find database connection information in %s: %s' % (file, e)
+        return None
+
+
+configs = [
+    ('/etc/neutron/neutron.conf', 'database', 'connection'),
+    ('/etc/quantum/quantum.conf', 'DATABASE', 'sql_connection'),
+    ('/etc/quantum/quantum.conf.rpmsave', 'DATABASE', 'sql_connection')
+]
+
+db_uri = None
+
+for (file, group, option) in configs:
+    db_uri = get_db_uri(file, group, option)
+    if db_uri:
+        break
+else:
+    print >>sys.stderr, 'Cannot find database connection information'
+    sys.exit(1)
+
+db = sqlalchemy.create_engine(db_uri)
+try:
+    connection = db.connect()
+except sqlalchemy.exc.SQLAlchemyError as e:
+    print >>sys.stderr, 'Cannot connect to database: %s' % e
+    sys.exit(1)
+
+to_update = []
+
+results = connection.execute("SELECT host FROM agents GROUP BY host;")
+for row in results:
+    if row['host'].endswith(domain):
+        to_update.append((row['host'], row['host'][:-len(domain)]))
+
+for fqdn, host in to_update:
+    print 'Updating agents to use "%s" as host, instead of "%s"...' % (host, fqdn)
+    connection.execute("UPDATE agents SET host = %s WHERE host = %s;", [host, fqdn])

--- a/lib/suse-cloud-upgrade-2.0-to-3-post
+++ b/lib/suse-cloud-upgrade-2.0-to-3-post
@@ -153,12 +153,18 @@ if test -f "${UPGRADE_DATA_DIR}/quantum/bc-quantum-default.json"; then
     done
   fi
 
-  value=$(json_read "$OLDJSONFILE" deployment.quantum.elements.quantum-server)
-  $json_edit "$JSONFILE" -a deployment.neutron.elements.neutron-server --raw -v "[ \"$value\" ]"
+  neutron_server=$(json_read "$OLDJSONFILE" deployment.quantum.elements.quantum-server)
+  $json_edit "$JSONFILE" -a deployment.neutron.elements.neutron-server --raw -v "[ \"$neutron_server\" ]"
 
   crowbar neutron proposal edit default --file "$JSONFILE"
 
   rm -f "$JSONFILE"
+
+  # also manually tweak the database if needed
+  if test -f "${UPGRADE_DATA_DIR}/quantum/db.stamp"; then
+    scp "`dirname $0`/quantum-to-neutron-helper" "${neutron_server}:/var/lib/quantum"
+    ssh "${neutron_server}" "/var/lib/quantum/quantum-to-neutron-helper $(hostname -d)"
+  fi
 else
   echo "No quantum proposal to migrate."
 fi


### PR DESCRIPTION
The host used to register agents in the neutron database is not a FQDN
anymore, while it was in quantum. So we need to update the database
accordingly, otherwise we lose networking.

See https://bugs.launchpad.net/neutron/+bug/1236439 and
https://wiki.openstack.org/wiki/ReleaseNotes/Havana#Agents_May_Report_a_Different_Host_Name
