### PR TITLE
Fix crash in post when /etc/crowbar/provisioner.json exists with no repo

### DIFF
--- a/lib/suse-cloud-upgrade-3-to-4-post
+++ b/lib/suse-cloud-upgrade-3-to-4-post
@@ -99,9 +99,9 @@ if test -f "$ETC_PROVISIONER_JSON"; then
         $json_edit "$NEW_PROVISIONER_JSON" -a "attributes.provisioner.suse.autoyast.repos.${attr_repo}.url" -v "$url"
       fi
     done
-  fi
 
-  crowbar provisioner proposal edit default --file "$NEW_PROVISIONER_JSON"
+    crowbar provisioner proposal edit default --file "$NEW_PROVISIONER_JSON"
+  fi
 fi
 
 


### PR DESCRIPTION
In that case, we don't need to edit the provisioner proposal, but we
were still trying to upload a json (which we didn't create before).
