### PR TITLE
Fix barclamp install order

### DIFF
--- a/lib/suse-cloud-upgrade-3-to-4-post
+++ b/lib/suse-cloud-upgrade-3-to-4-post
@@ -49,8 +49,8 @@ echo_summary "Reinstalling barclamps..."
 
 # order matters because of dependencies!
 for barclamp in crowbar deployer dns ipmi logging network ntp provisioner pacemaker \
-         database rabbitmq keystone swift ceph glance cinder neutron nova \
-         nova_dashboard openstack trove ; do
+         database rabbitmq openstack keystone swift ceph glance cinder neutron nova \
+         nova_dashboard trove ; do
     /opt/dell/bin/barclamp_install.rb --rpm $barclamp
 done
 


### PR DESCRIPTION
The "openstack" barclamp needs to come before any other openstack related
barclamps now. (https://bugzilla.suse.com/show_bug.cgi?id=898217)
