### PR TITLE
Bugfix: Removing trove and tempest before nova

### DIFF
--- a/lib/suse-cloud-upgrade-4-to-5-pre
+++ b/lib/suse-cloud-upgrade-4-to-5-pre
@@ -124,7 +124,7 @@ echo $neutron_nodes > ${UPGRADE_DATA_DIR}/neutron-server.nodes
 ### Deactivate all proposals
 echo_summary "Deactivating OpenStack barclamp proposals..."
 
-for barclamp in heat ceilometer nova_dashboard nova neutron cinder glance ceph swift keystone rabbitmq database pacemaker; do
+for barclamp in heat ceilometer nova_dashboard trove tempest nova neutron cinder glance ceph swift keystone rabbitmq database pacemaker; do
   applied_proposals=$(crowbar "$barclamp" list)
   if test "$applied_proposals" == "No current configurations"; then
     continue


### PR DESCRIPTION
The barclamps "trove" and "tempest" should be removed before removing nova. If you don't do that, you can get this error during installation: "Failed to talk to service delete: 500: Error, could not delete proposal.Cannot deactivate a proposal for nova, as it breaks dependencies of tempest-config-default and trove-config-default."
