### PR TITLE
Import repo directories from old Cloud 4 structure

### DIFF
--- a/lib/suse-cloud-upgrade-4-to-5-post
+++ b/lib/suse-cloud-upgrade-4-to-5-post
@@ -133,5 +133,9 @@ if test -f "$ETC_PROVISIONER_JSON"; then
 fi
 
 
+### Re-sign the PTF repos (as they got moved compared to Cloud 4)
+createrepo-cloud-ptf
+
+
 ### Done
 touch "${UPGRADE_DATA_DIR}/post.run"

--- a/lib/suse-cloud-upgrade-4-to-5-pre
+++ b/lib/suse-cloud-upgrade-4-to-5-pre
@@ -35,6 +35,44 @@ if test "x$suse_cloud_version" != "x4"; then
   die "Current installed version of SUSE Cloud is not 4: $suse_cloud_version"
 fi
 
+
+echo_summary "Ensuring SUSE Cloud 5 repositories are available..."
+
+# Populate new directory for repos
+old_repos_dir=/srv/tftpboot/repos
+repos_dir=/srv/tftpboot/suse-11.3/repos
+
+mkdir -p $repos_dir
+
+# Automatically create symlinks for new SMT-mirrored repos if they exist
+for repo in SUSE-Cloud-5-Pool \
+            SUSE-Cloud-5-Updates; do
+  cloud_dir=$repos_dir/$repo
+  smt_dir=/srv/www/htdocs/repo/\$RCE/$repo/sle-11-x86_64
+  test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+done
+
+# For SLE repos, try to re-use the same setup as before, or fallback to
+# symlinks to SMT-mirrored repos
+for repo in SLES11-SP3-Pool \
+            SLES11-SP3-Updates \
+            SLE11-HAE-SP3-Pool \
+            SLE11-HAE-SP3-Updates; do
+  cloud_dir=$repos_dir/$repo
+  smt_dir=/srv/www/htdocs/repo/\$RCE/$repo/sle-11-x86_64
+
+  test -e $cloud_dir && continue
+
+  if test -L $old_repos_dir/$repo -a -d "$(readlink $old_repos_dir/$repo)"; then
+    ln -s "$(readlink $old_repos_dir/$repo)" $cloud_dir
+  elif test -d $old_repos_dir/$repo; then
+    ln -s $old_repos_dir/$repo $cloud_dir
+  elif test -d $smt_dir; then
+    ln -s $smt_dir $cloud_dir
+  fi
+done
+
+
 echo_summary "Performing sanity checks..."
 
 

--- a/lib/suse-cloud-upgrade-4-to-5-pre
+++ b/lib/suse-cloud-upgrade-4-to-5-pre
@@ -41,8 +41,10 @@ echo_summary "Ensuring SUSE Cloud 5 repositories are available..."
 # Populate new directory for repos
 old_repos_dir=/srv/tftpboot/repos
 repos_dir=/srv/tftpboot/suse-11.3/repos
+repos12_dir=/srv/tftpboot/suse-12.0/repos
 
 mkdir -p $repos_dir
+mkdir -p $repos12_dir
 
 # Automatically create symlinks for new SMT-mirrored repos if they exist
 for repo in SUSE-Cloud-5-Pool \
@@ -71,6 +73,31 @@ for repo in SLES11-SP3-Pool \
     ln -s $smt_dir $cloud_dir
   fi
 done
+
+# Create symlinks for the SLE12 SMT-mirrored repos if they exist
+cloud_dir=$repos12_dir/SLES12-Pool
+smt_dir=/srv/www/htdocs/repo/SUSE/Products/SLE-SERVER/12/x86_64/product
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=$repos12_dir/SLES12-Updates
+smt_dir=/srv/www/htdocs/repo/SUSE/Updates/SLE-SERVER/12/x86_64/update
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=$repos12_dir/SLE-12-Cloud-Compute5-Pool
+smt_dir=/srv/www/htdocs/repo/SUSE/Products/12-Cloud-Compute/5/x86_64/product
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=$repos12_dir/SLE-12-Cloud-Compute5-Updates
+smt_dir=/srv/www/htdocs/repo/SUSE/Updates/12-Cloud-Compute/5/x86_64/update
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=$repos12_dir/SUSE-Enterprise-Storage-1.0-Pool
+smt_dir=/srv/www/htdocs/repo/SUSE/Products/Storage/1.0/x86_64/product
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=$repos12_dir/SUSE-Enterprise-Storage-1.0-Updates
+smt_dir=/srv/www/htdocs/repo/SUSE/Updates/Storage/1.0/x86_64/update
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
 
 
 echo_summary "Performing sanity checks..."


### PR DESCRIPTION
We also create symlinks to SMT repos for Cloud 5 repos on upgrade.

This depends on https://github.com/crowbar/crowbar/pull/2080