### PR TITLE
Set frame_max setting of rabbitmq to 0 during upgrade (bnc#910815)

### DIFF
--- a/lib/suse-cloud-upgrade-4-to-5-post
+++ b/lib/suse-cloud-upgrade-4-to-5-post
@@ -50,6 +50,17 @@ if test ! -f /etc/chef/amqp_passwd; then
   sed -i 's:^amqp_pass ".*":amqp_pass File.read("/etc/chef/amqp_passwd").chomp:' /etc/chef/{server,solr}.rb
 fi
 
+if test -f /etc/rabbitmq/rabbitmq-env.conf && \
+   grep -q ^SERVER_START_ARGS= /etc/rabbitmq/rabbitmq-env.conf && \
+   ! grep -q '^SERVER_START_ARGS=.*-rabbit frame_max 0' /etc/rabbitmq/rabbitmq-env.conf; then
+  die "SERVER_START_ARGS already defined in /etc/rabbitmq/rabbitmq-env.conf, without \"-rabbit frame_max 0\""
+elif ! ( test -f /etc/rabbitmq/rabbitmq-env.conf && \
+   grep -q ^SERVER_START_ARGS= /etc/rabbitmq/rabbitmq-env.conf ); then
+  echo '# Workaround for bunny version required by chef not supporting frames' >> /etc/rabbitmq/rabbitmq-env.conf
+  echo '# http://bugzilla.suse.com/show_bug.cgi?id=910815' >> /etc/rabbitmq/rabbitmq-env.conf
+  echo 'SERVER_START_ARGS="-rabbit frame_max 0"' >> /etc/rabbitmq/rabbitmq-env.conf
+fi
+
 rcrabbitmq-server start
 rccouchdb start
 rcchef-solr start


### PR DESCRIPTION
This is the same as https://github.com/crowbar/crowbar/pull/2084 for the
upgrade path from Cloud 4 to Cloud 5.

http://bugzilla.suse.com/show_bug.cgi?id=910815