### PR TITLE
Do not stop group resources when stopping HA resources

### DIFF
--- a/lib/suse-cloud-upgrade-4-to-5-pre
+++ b/lib/suse-cloud-upgrade-4-to-5-pre
@@ -258,7 +258,7 @@ echo_summary "Stopping pacemaker resources..."
 for founder in $cluster_founders; do
   echo "Stopping crm resources on ${founder}..."
   ssh "$founder" '
-    for type in clone group ms primitive; do
+    for type in clone ms primitive; do
       for resource in $(crm configure show | grep ^$type | cut -d " " -f2); do
         crm resource stop $resource
       done


### PR DESCRIPTION
This will create an issue when re-applying the proposals later on, as
resources will be told to start, but this will be masked by the group;
so they won't start and any check assuming they do start will fail.

Thanks to Adam Spiers <aspiers@suse.com> for finding the bug.