### PR TITLE
Complete fix for upgrade when some barclamps are not installed

### DIFF
--- a/lib/suse-cloud-upgrade-4-to-5-pre
+++ b/lib/suse-cloud-upgrade-4-to-5-pre
@@ -281,6 +281,10 @@ done
 sleep 10
 
 for barclamp in $deactivation_list; do
+  if [ ! -f "/opt/dell/crowbar_framework/barclamps/$barclamp.yml" ]; then
+    continue
+  fi
+
   applied_proposals=$(crowbar "$barclamp" list)
   if test "$applied_proposals" != "No current configurations"; then
     die "Was not able to deactivate all proposals for $barclamp."


### PR DESCRIPTION
We were skipping the deactivation, but not skipping the second check
later on.