### PR TITLE
Remove check that tells us that neutron-ns-metadata-proxy is running

### DIFF
--- a/lib/suse-cloud-upgrade-4-to-5-pre
+++ b/lib/suse-cloud-upgrade-4-to-5-pre
@@ -348,9 +348,6 @@ while [ "$services_stopped" != "yes" -a "$count" -lt 100 ]; do
           echo "$i still running at `hostname`"; exit 0
         fi
       done
-      if pgrep -f neutron-ns-metadata-proxy >/dev/null; then
-        echo "neutron proxy is still runing at `hostname`"
-      fi
       exit 1'; then
       services_stopped="no"
       break


### PR DESCRIPTION
This check can't work: ssh will start a shell process that will have
this string in the command line, so of course "pgrep -f" will always
tell us the process runs.

Since it's useless anyway, just drop it.