### PR TITLE
Remove old crowbar db migration script breaking upgrade

### DIFF
--- a/lib/suse-cloud-upgrade-4-to-5-post
+++ b/lib/suse-cloud-upgrade-4-to-5-post
@@ -104,6 +104,13 @@ export SECRET_KEY_BASE=$(cd /opt/dell/crowbar_framework && RAILS_ENV=production 
 EOF
 fi
 
+# Remove leftover file from Cloud 3 that breaks the update
+for file in /opt/dell/crowbar_framework/db/migrate/*_create_sessions.rb; do
+  if ! rpm -qf $file &> null; then
+    rm $file
+  fi
+done
+
 # Make sure that all files are up-to-date
 chef-client
 rcchef-client start


### PR DESCRIPTION
Cloud 3 had a file that was generated at runtime and that is left
around, breaking the start of crowbar after an upgrade to Cloud 5.

This old file is the cause of a ActiveRecord::PendingMigrationError
error on startup of crowbar.

This got properly added as part of
https://github.com/crowbar/barclamp-crowbar/pull/1045