### PR TITLE
Remove ceph package on upgrade from Cloud 4

### DIFF
--- a/lib/suse-cloud-upgrade-4-to-5-pre
+++ b/lib/suse-cloud-upgrade-4-to-5-pre
@@ -384,6 +384,12 @@ for node in $allocated_nodes; do
   ssh "$node" 'zypper mr -d SUSE-Cloud-4-Pool SUSE-Cloud-4-Updates'
 done
 
+# Remove packages that are not properly obsoleted
+for node in $allocated_nodes; do
+  echo "Removing obsolete packages on ${node}..."
+  ssh "$node" 'zypper rm -n --clean-deps ceph'
+done
+
 
 ### Disable crowbar and chef-client while packages get upgraded
 echo_summary "Stopping Crowbar..."


### PR DESCRIPTION
This package is in the Cloud 4 channel, but won't be available for
Cloud 5 (as it's not part of what's released for the ceph client-side
update on SLES11). Unfortunately, this package would block updating
other ceph subpackages, so we need to remove it manually.